### PR TITLE
Adding ability to pass width and height as props

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ React.render(
         onPanStart: function() { /* Pan started! */ },
         onPanStop: function() { /* Pan ended! */ },
         onPan: function() { /* Pan move! */ },
-
+        width: 800, // Optional width for the ElementPan container
+        height: 800, // Optional height for the ElementPan container
         startX: 771, // Optional X coordinate to start at
         startY: 360  // Optional Y coordinate to start at
     }, React.DOM.img({ src: 'some-large-image.jpg' })

--- a/src/element-pan.js
+++ b/src/element-pan.js
@@ -14,7 +14,9 @@ var ElementPan = React.createClass({
         onPan: PropTypes.func,
         onPanStop: PropTypes.func,
         startX: PropTypes.number,
-        startY: PropTypes.number
+        startY: PropTypes.number,
+        width: PropTypes.number,
+        height: PropTypes.number
     },
 
     getDefaultProps: function() {
@@ -134,12 +136,29 @@ var ElementPan = React.createClass({
         }
     },
 
+    getContainerStyles: function() {
+        var style = {
+            overflow: 'hidden',
+            cursor: 'move'            
+        }
+
+        if(this.props.width) {
+            style.width = this.props.width + "px";
+        }
+
+        if(this.props.height) {
+            style.height = this.props.height + "px";
+        }
+
+        return style;
+    },
+
     render: function() {
         return (
             React.DOM.div({
                 ref: 'container',
                 className: this.props.className,
-                style: { overflow: 'hidden', cursor: 'move' },
+                style: this.getContainerStyles(),
                 onMouseDown: this.onDragStart,
                 onTouchStart: this.onDragStart
             }, this.props.children)

--- a/src/element-pan.js
+++ b/src/element-pan.js
@@ -142,12 +142,12 @@ var ElementPan = React.createClass({
             cursor: 'move'            
         }
 
-        if(this.props.width) {
-            style.width = this.props.width + "px";
+        if (this.props.width) {
+            style.width = this.props.width + 'px';
         }
 
-        if(this.props.height) {
-            style.height = this.props.height + "px";
+        if (this.props.height) {
+            style.height = this.props.height + 'px';
         }
 
         return style;


### PR DESCRIPTION
Hi @rexxars ,

Adding support to pass `width` and `height` as props to the `ElementPan` container as a part of this PR. These props will be applied as inline styles on the element. This is useful when we calculate the `ElementPan` dimensions programmatically instead of defining them via a css style class.

Let me know if this seems a valid solution. I am open to any other way for solving this. Also I need some help publishing this if this gets merged into master :) 

Thanks,
Nikhilesh

//cc @rexxars 
