### PR TITLE
Fixed touch handling for children inside the pan element

### DIFF
--- a/src/element-pan.js
+++ b/src/element-pan.js
@@ -33,8 +33,6 @@ var ElementPan = React.createClass({
     },
 
     onDragStart: function(e) {
-        e.preventDefault();
-
         // We want to be able to pan around inside the container even when the
         // mouse is on the outside of the element (as long as the mouse button
         // is still being pressed) - this is why we're attaching to the window
@@ -80,6 +78,8 @@ var ElementPan = React.createClass({
     },
 
     onDragMove: function(e) {
+	    e.preventDefault();
+		
         if (!this.state.dragging) {
             return;
         }

--- a/src/element-pan.js
+++ b/src/element-pan.js
@@ -78,8 +78,8 @@ var ElementPan = React.createClass({
     },
 
     onDragMove: function(e) {
-	e.preventDefault();
-		
+        e.preventDefault();
+
         if (!this.state.dragging) {
             return;
         }

--- a/src/element-pan.js
+++ b/src/element-pan.js
@@ -78,7 +78,7 @@ var ElementPan = React.createClass({
     },
 
     onDragMove: function(e) {
-	    e.preventDefault();
+	e.preventDefault();
 		
         if (!this.state.dragging) {
             return;


### PR DESCRIPTION
Touch events for children inside the pan element didn't work. The root cause was e.preventDefault() on dragStart event (it blocked touch event for children), so I moved it to on dragMove and now everything works great.