### PR TITLE
Fixed problem with preventing touch event

### DIFF
--- a/src/element-pan.js
+++ b/src/element-pan.js
@@ -19,7 +19,7 @@ class ElementPan extends React.Component {
     // mouse is on the outside of the element (as long as the mouse button
     // is still being pressed) - this is why we're attaching to the window
     eventListener.add(window, 'mousemove', this.onDragMove)
-    eventListener.add(window, 'touchmove', this.onDragMove)
+    eventListener.add(window, 'touchmove', this.onDragMove, {passive: false})
     eventListener.add(window, 'mouseup', this.onDragStop)
     eventListener.add(window, 'touchend', this.onDragStop)
 


### PR DESCRIPTION
Hello!
Thank you for the react-element-pan component, it's really helpful and easy to use!

However I encountered the following warning while using in latest Chrome (version 67.0.3396.99).

`[Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive. See https://www.chromestatus.com/features/5093566007214080`

[Chromestatus says](https://www.chromestatus.com/features/5093566007214080) that since version 56 touch events are passive by default, so that calls to preventDefault for them are ignored.

So I decided to fix this small issue and explicitly marked the touchmove event as not passive.

